### PR TITLE
Fix bug introduced in PR#3891, auto_https should never be set to `on`

### DIFF
--- a/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
+++ b/www/caddy/src/opnsense/service/templates/OPNsense/Caddy/Caddyfile
@@ -273,8 +273,14 @@
     {% if emailValue %}
     email {{ emailValue }}
     {% endif %}
+
+    {#
+    #   Upstream docs: https://caddyserver.com/docs/caddyfile/options#auto-https
+    #   Note: if value is `on`, do not emit directive to caddyfile. `on` is default, and
+    #         should be omitted if that effect is desired.
+    #}
     {% set autoHttpsValue = helpers.toList('Pischem.caddy.general.TlsAutoHttps') | first %}
-    {% if autoHttpsValue %}
+    {% if autoHttpsValue != 'on' %}
     auto_https {{ autoHttpsValue }}
     {% endif %}
     import /usr/local/etc/caddy/caddy.d/*.global


### PR DESCRIPTION
upstream docs: https://caddyserver.com/docs/caddyfile/options#auto-https

For some reason, the caddy directive `auto_https` cannot take a value of `on`, but instead just shouldn't be called.